### PR TITLE
Add board renaming with dynamic routing

### DIFF
--- a/DYNAMODB_MIGRATION.md
+++ b/DYNAMODB_MIGRATION.md
@@ -79,10 +79,10 @@ For local development, you can use DynamoDB Local with Docker:
 
 ```bash
 # Start DynamoDB Local
-docker run -p 8000:8000 amazon/dynamodb-local
+docker run -p 8001:8001 amazon/dynamodb-local
 
 # Set environment variable
-export DYNAMODB_ENDPOINT_URL=http://localhost:8000
+export DYNAMODB_ENDPOINT_URL=http://localhost:8001
 ```
 
 ### Database Table Creation

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -896,3 +896,172 @@ def delete_township(township_id: str) -> bool:
     except ClientError as e:
         print(f"Error deleting township {township_id}: {e}")
         return False
+
+
+# Board Configuration CRUD operations
+def create_board_configuration(board_config: schemas.BoardConfigurationCreate) -> BoardConfiguration:
+    """Create a new board configuration"""
+    table = get_table('BoardConfigurations')
+    try:
+        # Create a slug from board name (simple version)
+        board_slug = board_config.BoardName.lower().replace(' ', '-').replace('_', '-')
+        # Remove special characters for URL safety
+        import re
+        board_slug = re.sub(r'[^a-z0-9\-]', '', board_slug)
+        
+        new_config = BoardConfiguration(
+            BoardName=board_config.BoardName,
+            BoardSlug=board_slug,
+            Description=board_config.Description,
+            UserId=board_config.UserId,
+            IsDefault=board_config.IsDefault,
+            CreatedBy="system"  # TODO: get from auth context
+        )
+        
+        serialized_config = serialize_item(new_config.dict())
+        table.put_item(Item=serialized_config)
+        
+        return new_config
+        
+    except ClientError as e:
+        print(f"Error creating board configuration: {e}")
+        return None
+
+
+def get_board_configuration(board_config_id: str) -> BoardConfiguration:
+    """Get a board configuration by ID"""
+    table = get_table('BoardConfigurations')
+    try:
+        response = table.get_item(Key={'BoardConfigId': board_config_id})
+        item = response.get('Item')
+        if item:
+            return BoardConfiguration(**deserialize_item(item))
+        return None
+        
+    except ClientError as e:
+        print(f"Error getting board configuration {board_config_id}: {e}")
+        return None
+
+
+def get_board_configuration_by_slug(board_slug: str) -> BoardConfiguration:
+    """Get a board configuration by slug"""
+    table = get_table('BoardConfigurations')
+    try:
+        response = table.query(
+            IndexName='BoardSlugIndex',
+            KeyConditionExpression=Key('BoardSlug').eq(board_slug),
+            FilterExpression=Attr('IsActive').eq(True)
+        )
+        items = response.get('Items', [])
+        if items:
+            return BoardConfiguration(**deserialize_item(items[0]))
+        return None
+        
+    except ClientError as e:
+        print(f"Error getting board configuration by slug {board_slug}: {e}")
+        return None
+
+
+def get_board_configurations() -> List[BoardConfiguration]:
+    """Get all active board configurations"""
+    table = get_table('BoardConfigurations')
+    try:
+        response = table.scan(
+            FilterExpression=Attr('IsActive').eq(True)
+        )
+        items = response.get('Items', [])
+        return [BoardConfiguration(**deserialize_item(item)) for item in items]
+        
+    except ClientError as e:
+        print(f"Error getting board configurations: {e}")
+        return []
+
+
+def get_default_board_configuration() -> BoardConfiguration:
+    """Get the default board configuration"""
+    table = get_table('BoardConfigurations')
+    try:
+        response = table.scan(
+            FilterExpression=Attr('IsDefault').eq(True) & Attr('IsActive').eq(True)
+        )
+        items = response.get('Items', [])
+        if items:
+            return BoardConfiguration(**deserialize_item(items[0]))
+        return None
+        
+    except ClientError as e:
+        print(f"Error getting default board configuration: {e}")
+        return None
+
+
+def update_board_configuration(board_config_id: str, board_config: schemas.BoardConfigurationUpdate) -> BoardConfiguration:
+    """Update a board configuration"""
+    table = get_table('BoardConfigurations')
+    try:
+        # Build update expression
+        update_expression = "SET ModifiedDate = :modified_date, ModifiedBy = :modified_by"
+        expression_values = {
+            ':modified_date': serialize_datetime(datetime.utcnow()),
+            ':modified_by': "system"  # TODO: get from auth context
+        }
+        
+        if board_config.BoardName is not None:
+            # Create new slug from updated name
+            board_slug = board_config.BoardName.lower().replace(' ', '-').replace('_', '-')
+            import re
+            board_slug = re.sub(r'[^a-z0-9\-]', '', board_slug)
+            
+            update_expression += ", BoardName = :board_name, BoardSlug = :board_slug"
+            expression_values[':board_name'] = board_config.BoardName
+            expression_values[':board_slug'] = board_slug
+        
+        if board_config.Description is not None:
+            update_expression += ", Description = :description"
+            expression_values[':description'] = board_config.Description
+        
+        if board_config.IsDefault is not None:
+            update_expression += ", IsDefault = :is_default"
+            expression_values[':is_default'] = board_config.IsDefault
+        
+        if board_config.IsActive is not None:
+            update_expression += ", IsActive = :is_active"
+            expression_values[':is_active'] = board_config.IsActive
+        
+        # Update in DynamoDB
+        response = table.update_item(
+            Key={'BoardConfigId': board_config_id},
+            UpdateExpression=update_expression,
+            ExpressionAttributeValues=expression_values,
+            ReturnValues='ALL_NEW'
+        )
+        
+        # Return updated board configuration
+        item = response.get('Attributes')
+        if item:
+            return BoardConfiguration(**deserialize_item(item))
+        return None
+        
+    except ClientError as e:
+        print(f"Error updating board configuration {board_config_id}: {e}")
+        return None
+
+
+def delete_board_configuration(board_config_id: str) -> bool:
+    """Soft delete a board configuration by setting IsActive to False"""
+    table = get_table('BoardConfigurations')
+    try:
+        # Update IsActive to False instead of actually deleting
+        table.update_item(
+            Key={'BoardConfigId': board_config_id},
+            UpdateExpression='SET IsActive = :is_active, ModifiedDate = :modified_date, ModifiedBy = :modified_by',
+            ExpressionAttributeValues={
+                ':is_active': False,
+                ':modified_date': serialize_datetime(datetime.utcnow()),
+                ':modified_by': "system"  # TODO: get from auth context
+            }
+        )
+        return True
+        
+    except ClientError as e:
+        print(f"Error deleting board configuration {board_config_id}: {e}")
+        return False

--- a/backend/graphql_schema_simple.py
+++ b/backend/graphql_schema_simple.py
@@ -123,6 +123,25 @@ class TownshipListResponse(ObjectType):
     page = Int()
     size = Int()
 
+class BoardConfigurationType(ObjectType):
+    BoardConfigId = String()
+    BoardName = String()
+    BoardSlug = String()
+    Description = String()
+    UserId = String()
+    IsDefault = Boolean()
+    IsActive = Boolean()
+    CreatedDate = DateTime()
+    ModifiedDate = DateTime()
+    CreatedBy = String()
+    ModifiedBy = String()
+
+class BoardConfigurationListResponse(ObjectType):
+    board_configurations = List(BoardConfigurationType)
+    total = Int()
+    page = Int()
+    size = Int()
+
 def model_to_survey(survey):
     """Convert Survey model to GraphQL type"""
     if not survey:
@@ -291,6 +310,24 @@ def model_to_survey_status(survey_status):
         IsActive=getattr(survey_status, 'IsActive', True)
     )
 
+def model_to_board_configuration(board_config):
+    """Convert BoardConfiguration model to GraphQL type"""
+    if not board_config:
+        return None
+    return BoardConfigurationType(
+        BoardConfigId=getattr(board_config, 'BoardConfigId', ''),
+        BoardName=getattr(board_config, 'BoardName', ''),
+        BoardSlug=getattr(board_config, 'BoardSlug', ''),
+        Description=getattr(board_config, 'Description', ''),
+        UserId=getattr(board_config, 'UserId', ''),
+        IsDefault=getattr(board_config, 'IsDefault', False),
+        IsActive=getattr(board_config, 'IsActive', True),
+        CreatedDate=getattr(board_config, 'CreatedDate', None),
+        ModifiedDate=getattr(board_config, 'ModifiedDate', None),
+        CreatedBy=getattr(board_config, 'CreatedBy', ''),
+        ModifiedBy=getattr(board_config, 'ModifiedBy', '')
+    )
+
 class Query(ObjectType):
     surveys = Field(SurveyListResponse, skip=Int(default_value=0), limit=Int(default_value=100), search=String())
     survey = Field(SurveyType, surveyId=String(required=True))
@@ -302,6 +339,10 @@ class Query(ObjectType):
     township = Field(TownshipType, townshipId=String(required=True))
     surveyTypes = Field(List(SurveyTypeType))
     surveyStatuses = Field(List(SurveyStatusType))
+    boardConfigurations = Field(List(BoardConfigurationType))
+    boardConfiguration = Field(BoardConfigurationType, boardConfigId=String(required=True))
+    boardConfigurationBySlug = Field(BoardConfigurationType, boardSlug=String(required=True))
+    defaultBoardConfiguration = Field(BoardConfigurationType)
 
     def resolve_surveys(self, info, skip=0, limit=100, search=None):
         try:
@@ -406,6 +447,44 @@ class Query(ObjectType):
         except Exception as e:
             print(f"Error resolving survey statuses: {e}")
             return []
+
+    def resolve_boardConfigurations(self, info):
+        try:
+            board_configurations = crud.get_board_configurations()
+            return [model_to_board_configuration(bc) for bc in board_configurations]
+        except Exception as e:
+            print(f"Error resolving board configurations: {e}")
+            return []
+
+    def resolve_boardConfiguration(self, info, boardConfigId):
+        try:
+            board_config = crud.get_board_configuration(board_config_id=boardConfigId)
+            if board_config:
+                return model_to_board_configuration(board_config)
+            return None
+        except Exception as e:
+            print(f"Error resolving board configuration: {e}")
+            return None
+
+    def resolve_boardConfigurationBySlug(self, info, boardSlug):
+        try:
+            board_config = crud.get_board_configuration_by_slug(board_slug=boardSlug)
+            if board_config:
+                return model_to_board_configuration(board_config)
+            return None
+        except Exception as e:
+            print(f"Error resolving board configuration by slug: {e}")
+            return None
+
+    def resolve_defaultBoardConfiguration(self, info):
+        try:
+            board_config = crud.get_default_board_configuration()
+            if board_config:
+                return model_to_board_configuration(board_config)
+            return None
+        except Exception as e:
+            print(f"Error resolving default board configuration: {e}")
+            return None
 
 # Create simple schema with queries and mutations
 class CreateCustomerInput(graphene.InputObjectType):
@@ -590,6 +669,20 @@ class SurveyUpdateInput(graphene.InputObjectType):
     IsDrawingComplete = Boolean()
     IsScanned = Boolean()
     IsDelivered = Boolean()
+    IsActive = Boolean()
+
+class BoardConfigurationInput(graphene.InputObjectType):
+    BoardName = String(required=True)
+    Description = String()
+    UserId = String()
+    IsDefault = Boolean()
+    IsActive = Boolean()
+
+class BoardConfigurationUpdateInput(graphene.InputObjectType):
+    BoardName = String()
+    BoardSlug = String()
+    Description = String()
+    IsDefault = Boolean()
     IsActive = Boolean()
 
 class CreateCustomerMutation(graphene.Mutation):
@@ -1049,6 +1142,75 @@ class UpdateSurveyMutation(graphene.Mutation):
             traceback.print_exc()
             return UpdateSurveyMutation(survey=None)
 
+class CreateBoardConfigurationMutation(graphene.Mutation):
+    class Arguments:
+        board_config = BoardConfigurationInput(required=True)
+    
+    board_configuration = Field(BoardConfigurationType)
+    
+    def mutate(self, info, board_config):
+        try:
+            import schemas
+            config_data = schemas.BoardConfigurationCreate(
+                BoardName=board_config.BoardName,
+                Description=board_config.Description,
+                UserId=board_config.UserId,
+                IsDefault=board_config.IsDefault if board_config.IsDefault is not None else False,
+                IsActive=board_config.IsActive if board_config.IsActive is not None else True
+            )
+            new_config = crud.create_board_configuration(config_data)
+            if new_config:
+                return CreateBoardConfigurationMutation(board_configuration=model_to_board_configuration(new_config))
+            else:
+                return CreateBoardConfigurationMutation(board_configuration=None)
+        except Exception as e:
+            print(f"Error creating board configuration: {e}")
+            import traceback
+            traceback.print_exc()
+            return CreateBoardConfigurationMutation(board_configuration=None)
+
+class UpdateBoardConfigurationMutation(graphene.Mutation):
+    class Arguments:
+        board_config_id = String(required=True)
+        board_config = BoardConfigurationUpdateInput(required=True)
+    
+    board_configuration = Field(BoardConfigurationType)
+    
+    def mutate(self, info, board_config_id, board_config):
+        try:
+            import schemas
+            config_data = schemas.BoardConfigurationUpdate(
+                BoardName=board_config.BoardName,
+                BoardSlug=board_config.BoardSlug,
+                Description=board_config.Description,
+                IsDefault=board_config.IsDefault,
+                IsActive=board_config.IsActive
+            )
+            updated_config = crud.update_board_configuration(board_config_id, config_data)
+            if updated_config:
+                return UpdateBoardConfigurationMutation(board_configuration=model_to_board_configuration(updated_config))
+            else:
+                return UpdateBoardConfigurationMutation(board_configuration=None)
+        except Exception as e:
+            print(f"Error updating board configuration: {e}")
+            import traceback
+            traceback.print_exc()
+            return UpdateBoardConfigurationMutation(board_configuration=None)
+
+class DeleteBoardConfigurationMutation(graphene.Mutation):
+    class Arguments:
+        board_config_id = String(required=True)
+    
+    success = Boolean()
+    
+    def mutate(self, info, board_config_id):
+        try:
+            success = crud.delete_board_configuration(board_config_id)
+            return DeleteBoardConfigurationMutation(success=success)
+        except Exception as e:
+            print(f"Error deleting board configuration: {e}")
+            return DeleteBoardConfigurationMutation(success=False)
+
 class Mutation(graphene.ObjectType):
     createCustomer = CreateCustomerMutation.Field()
     updateCustomer = UpdateCustomerMutation.Field()
@@ -1064,5 +1226,8 @@ class Mutation(graphene.ObjectType):
     createSurveyType = CreateSurveyTypeMutation.Field()
     createSurveyStatus = CreateSurveyStatusMutation.Field()
     updateSurveyStatus = UpdateSurveyStatusMutation.Field()
+    createBoardConfiguration = CreateBoardConfigurationMutation.Field()
+    updateBoardConfiguration = UpdateBoardConfigurationMutation.Field()
+    deleteBoardConfiguration = DeleteBoardConfigurationMutation.Field()
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, HTMLResponse
 import graphene
-from routers import customers, surveys, properties, lookup, townships
+from routers import customers, surveys, properties, lookup, townships, board_configurations
 from graphql_schema_simple import schema
 
 app = FastAPI(
@@ -82,6 +82,7 @@ app.include_router(surveys.router, prefix="/api")
 app.include_router(properties.router, prefix="/api")
 app.include_router(townships.router, prefix="/api")
 app.include_router(lookup.router, prefix="/api")
+app.include_router(board_configurations.router, prefix="/api")
 
 @app.get("/")
 def read_root():

--- a/backend/models.py
+++ b/backend/models.py
@@ -197,6 +197,24 @@ class Document(BaseModel):
             datetime: lambda v: v.isoformat()
         }
 
+class BoardConfiguration(BaseModel):
+    BoardConfigId: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    BoardName: str
+    BoardSlug: str  # URL-friendly version of the board name
+    Description: Optional[str] = None
+    UserId: Optional[str] = None  # For user-specific boards in the future
+    IsDefault: bool = False
+    IsActive: bool = True
+    CreatedDate: datetime = Field(default_factory=datetime.utcnow)
+    ModifiedDate: datetime = Field(default_factory=datetime.utcnow)
+    CreatedBy: Optional[str] = None
+    ModifiedBy: Optional[str] = None
+    
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat()
+        }
+
 # DynamoDB table configurations
 DYNAMODB_TABLES = {
     'Addresses': {
@@ -366,6 +384,31 @@ DYNAMODB_TABLES = {
         ],
         'AttributeDefinitions': [
             {'AttributeName': 'DocumentId', 'AttributeType': 'S'}
+        ]
+    },
+    'BoardConfigurations': {
+        'TableName': 'BoardConfigurations',
+        'KeySchema': [
+            {'AttributeName': 'BoardConfigId', 'KeyType': 'HASH'}
+        ],
+        'AttributeDefinitions': [
+            {'AttributeName': 'BoardConfigId', 'AttributeType': 'S'},
+            {'AttributeName': 'BoardSlug', 'AttributeType': 'S'},
+            {'AttributeName': 'UserId', 'AttributeType': 'S'}
+        ],
+        'GlobalSecondaryIndexes': [
+            {
+                'IndexName': 'BoardSlugIndex',
+                'KeySchema': [
+                    {'AttributeName': 'BoardSlug', 'KeyType': 'HASH'}
+                ]
+            },
+            {
+                'IndexName': 'UserIdIndex',
+                'KeySchema': [
+                    {'AttributeName': 'UserId', 'KeyType': 'HASH'}
+                ]
+            }
         ]
     }
 }

--- a/backend/routers/board_configurations.py
+++ b/backend/routers/board_configurations.py
@@ -1,0 +1,110 @@
+from fastapi import APIRouter, HTTPException, Path, Query
+from typing import List, Optional
+
+import crud
+import schemas
+from models import BoardConfiguration
+
+router = APIRouter(
+    prefix="/board-configurations",
+    tags=["board-configurations"]
+)
+
+
+@router.post("/", response_model=BoardConfiguration)
+def create_board_configuration(board_config: schemas.BoardConfigurationCreate):
+    """Create a new board configuration"""
+    try:
+        db_config = crud.create_board_configuration(board_config)
+        if not db_config:
+            raise HTTPException(status_code=400, detail="Failed to create board configuration")
+        return db_config
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@router.get("/", response_model=List[BoardConfiguration])
+def get_board_configurations():
+    """Get all active board configurations"""
+    try:
+        return crud.get_board_configurations()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@router.get("/default", response_model=BoardConfiguration)
+def get_default_board_configuration():
+    """Get the default board configuration"""
+    try:
+        config = crud.get_default_board_configuration()
+        if not config:
+            raise HTTPException(status_code=404, detail="No default board configuration found")
+        return config
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@router.get("/by-slug/{board_slug}", response_model=BoardConfiguration)
+def get_board_configuration_by_slug(board_slug: str = Path(..., description="Board URL slug")):
+    """Get a board configuration by its URL slug"""
+    try:
+        config = crud.get_board_configuration_by_slug(board_slug)
+        if not config:
+            raise HTTPException(status_code=404, detail="Board configuration not found")
+        return config
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@router.get("/{board_config_id}", response_model=BoardConfiguration)
+def get_board_configuration(board_config_id: str = Path(..., description="Board configuration ID")):
+    """Get a board configuration by ID"""
+    try:
+        config = crud.get_board_configuration(board_config_id)
+        if not config:
+            raise HTTPException(status_code=404, detail="Board configuration not found")
+        return config
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@router.put("/{board_config_id}", response_model=BoardConfiguration)
+def update_board_configuration(
+    board_config_id: str, 
+    board_config: schemas.BoardConfigurationUpdate
+):
+    """Update a board configuration"""
+    try:
+        # First check if the board configuration exists
+        existing = crud.get_board_configuration(board_config_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="Board configuration not found")
+        
+        updated_config = crud.update_board_configuration(board_config_id, board_config)
+        if not updated_config:
+            raise HTTPException(status_code=400, detail="Failed to update board configuration")
+        return updated_config
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+@router.delete("/{board_config_id}")
+def delete_board_configuration(board_config_id: str = Path(..., description="Board configuration ID")):
+    """Soft delete a board configuration (set IsActive to False)"""
+    try:
+        # First check if the board configuration exists
+        existing = crud.get_board_configuration(board_config_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="Board configuration not found")
+        
+        success = crud.delete_board_configuration(board_config_id)
+        if not success:
+            raise HTTPException(status_code=400, detail="Failed to delete board configuration")
+        
+        return {"message": "Board configuration deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -307,3 +307,37 @@ class PropertyListResponse(BaseModel):
     total: int
     page: int
     size: int
+
+# Board Configuration Schemas
+class BoardConfigurationBase(BaseModel):
+    BoardName: str
+    Description: Optional[str] = None
+    UserId: Optional[str] = None
+    IsDefault: bool = False
+    IsActive: bool = True
+
+class BoardConfigurationCreate(BoardConfigurationBase):
+    pass
+
+class BoardConfigurationUpdate(BaseModel):
+    BoardName: Optional[str] = None
+    Description: Optional[str] = None
+    IsDefault: Optional[bool] = None
+    IsActive: Optional[bool] = None
+
+class BoardConfiguration(BoardConfigurationBase):
+    BoardConfigId: str
+    BoardSlug: str
+    CreatedDate: datetime
+    ModifiedDate: datetime
+    CreatedBy: Optional[str] = None
+    ModifiedBy: Optional[str] = None
+    
+    class Config:
+        from_attributes = True
+
+class BoardConfigurationListResponse(BaseModel):
+    board_configurations: List[BoardConfiguration]
+    total: int
+    page: int
+    size: int

--- a/backend/seed_database.py
+++ b/backend/seed_database.py
@@ -12,6 +12,11 @@ from botocore.exceptions import ClientError
 import uuid
 from datetime import datetime
 
+# Add environment variables for local DynamoDB at the top
+os.environ['AWS_ACCESS_KEY_ID'] = 'fake'
+os.environ['AWS_SECRET_ACCESS_KEY'] = 'fake'
+os.environ['DYNAMODB_ENDPOINT_URL'] = 'http://localhost:8001'
+
 # Add the backend directory to the Python path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 

--- a/backend/seed_database.py
+++ b/backend/seed_database.py
@@ -13,18 +13,14 @@ from botocore.exceptions import ClientError
 # Add the backend directory to the Python path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from models import SurveyType, SurveyStatus
+from models import SurveyType, SurveyStatus, BoardConfiguration
+from database import get_dynamodb
 import crud
+import schemas
 
 def get_local_dynamodb():
-    """Get a direct connection to local moto DynamoDB"""
-    return boto3.resource(
-        'dynamodb',
-        endpoint_url='http://localhost:8001',
-        aws_access_key_id='fake_access_key',
-        aws_secret_access_key='fake_secret_key',
-        region_name='us-east-1'
-    )
+    """Get a connection to local DynamoDB using the same method as the application"""
+    return get_dynamodb()
 
 def get_survey_types_direct():
     """Get survey types directly from local DynamoDB"""
@@ -218,15 +214,60 @@ def seed_survey_statuses():
     print(f"Created {created_count} survey statuses out of {len(survey_statuses)} total.")
     return created_count
 
+def get_board_configurations_direct():
+    """Get board configurations directly from local DynamoDB"""
+    try:
+        dynamodb = get_local_dynamodb()
+        table = dynamodb.Table('BoardConfigurations')
+        response = table.scan(
+            FilterExpression=Attr('IsActive').eq(True)
+        )
+        return response.get('Items', [])
+    except Exception as e:
+        print(f"Error getting board configurations: {e}")
+        return []
+
+
+def seed_board_configurations():
+    """Seed default board configurations"""
+    print("\nSeeding board configurations...")
+    
+    # Default board configuration
+    default_boards = [
+        {
+            "BoardName": "Survey Board",
+            "Description": "Default kanban board for managing surveys",
+            "IsDefault": True
+        }
+    ]
+    
+    created_count = 0
+    for board_data in default_boards:
+        try:
+            board_config = schemas.BoardConfigurationCreate(**board_data)
+            result = crud.create_board_configuration(board_config)
+            if result:
+                created_count += 1
+                print(f"  ✓ Created board configuration: {board_data['BoardName']}")
+            else:
+                print(f"  ✗ Failed to create board configuration: {board_data['BoardName']}")
+        except Exception as e:
+            print(f"  ✗ Error creating board configuration {board_data['BoardName']}: {e}")
+    
+    return created_count
+
+
 def check_existing_data():
     """Check if there's already data in the tables"""
     existing_types = get_survey_types_direct()
     existing_statuses = get_survey_statuses_direct()
+    existing_boards = get_board_configurations_direct()
     
     print(f"Existing survey types: {len(existing_types)}")
     print(f"Existing survey statuses: {len(existing_statuses)}")
+    print(f"Existing board configurations: {len(existing_boards)}")
     
-    return len(existing_types), len(existing_statuses)
+    return len(existing_types), len(existing_statuses), len(existing_boards)
 
 def main():
     """Main seeding function"""
@@ -236,9 +277,9 @@ def main():
     
     try:
         # Check existing data
-        type_count, status_count = check_existing_data()
+        type_count, status_count, board_count = check_existing_data()
         
-        if type_count > 0 or status_count > 0:
+        if type_count > 0 or status_count > 0 or board_count > 0:
             print(f"\nWarning: Found existing data in tables.")
             response = input("Do you want to proceed anyway? (y/N): ")
             if response.lower() not in ['y', 'yes']:
@@ -248,14 +289,16 @@ def main():
         # Seed the data
         types_created = seed_survey_types()
         statuses_created = seed_survey_statuses()
+        boards_created = seed_board_configurations()
         
         print("\n" + "=" * 60)
         print("Seeding Summary:")
         print(f"Survey Types Created: {types_created}")
         print(f"Survey Statuses Created: {statuses_created}")
+        print(f"Board Configurations Created: {boards_created}")
         print("=" * 60)
         
-        if types_created > 0 or statuses_created > 0:
+        if types_created > 0 or statuses_created > 0 or boards_created > 0:
             print("✓ Database seeding completed successfully!")
         else:
             print("⚠ No new records were created.")

--- a/backend/setup_tables.py
+++ b/backend/setup_tables.py
@@ -143,7 +143,8 @@ def setup_all_tables():
         'SurveyStatuses', 
         'Surveys',
         'SurveyFiles',
-        'Documents'
+        'Documents',
+        'BoardConfigurations'
     ]
     
     print(f"\n📋 Required tables: {all_tables}")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,6 +96,7 @@ function App() {
               <Route path="/" element={<Dashboard />} />
               <Route path="/surveys" element={<Surveys />} />
               <Route path="/board" element={<Board />} />
+              <Route path="/board/:boardSlug" element={<Board />} />
               <Route path="/customers" element={<Customers />} />
               <Route path="/properties" element={<Properties />} />
               <Route path="/townships" element={<Townships />} />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { 
   BuildingOfficeIcon, 
@@ -8,11 +8,11 @@ import {
   MapIcon,
   Squares2X2Icon
 } from '@heroicons/react/24/outline';
+import { useDefaultBoardConfiguration } from '../hooks/useGraphQLApi';
 
-const navigation = [
+const staticNavigation = [
   { name: 'Dashboard', href: '/', icon: HomeIcon },
   { name: 'Surveys', href: '/surveys', icon: DocumentTextIcon },
-  { name: 'Board', href: '/board', icon: Squares2X2Icon },
   { name: 'Customers', href: '/customers', icon: UsersIcon },
   { name: 'Properties', href: '/properties', icon: BuildingOfficeIcon },
   { name: 'Townships', href: '/townships', icon: MapIcon },
@@ -24,6 +24,30 @@ function classNames(...classes: string[]) {
 
 export default function Sidebar() {
   const location = useLocation();
+  const { data: defaultBoardConfig } = useDefaultBoardConfiguration();
+  const [boardNavItem, setBoardNavItem] = useState({ 
+    name: 'Board', 
+    href: '/board', 
+    icon: Squares2X2Icon 
+  });
+
+  // Update board navigation when configuration changes
+  useEffect(() => {
+    if (defaultBoardConfig) {
+      setBoardNavItem({
+        name: defaultBoardConfig.BoardName || 'Board',
+        href: defaultBoardConfig.BoardSlug ? `/board/${defaultBoardConfig.BoardSlug}` : '/board',
+        icon: Squares2X2Icon
+      });
+    }
+  }, [defaultBoardConfig]);
+
+  // Create navigation with dynamic board item
+  const navigation = [
+    ...staticNavigation.slice(0, 2), // Dashboard, Surveys
+    boardNavItem, // Dynamic board item
+    ...staticNavigation.slice(2) // Customers, Properties, Townships
+  ];
 
   return (
     <div className="flex flex-col w-64 bg-gray-800">
@@ -32,7 +56,8 @@ export default function Sidebar() {
       </div>
       <nav className="flex-1 px-2 py-4 space-y-1">
         {navigation.map((item) => {
-          const isCurrent = location.pathname === item.href;
+          const isCurrent = location.pathname === item.href || 
+                           (item.href.startsWith('/board') && location.pathname.startsWith('/board'));
           return (
             <Link
               key={item.name}

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -496,3 +496,125 @@ export const DELETE_TOWNSHIP = gql`
     }
   }
 `;
+
+// Board Configuration Queries
+export const GET_BOARD_CONFIGURATIONS = gql`
+  query GetBoardConfigurations {
+    boardConfigurations {
+      BoardConfigId
+      BoardName
+      BoardSlug
+      Description
+      UserId
+      IsDefault
+      IsActive
+      CreatedDate
+      ModifiedDate
+      CreatedBy
+      ModifiedBy
+    }
+  }
+`;
+
+export const GET_BOARD_CONFIGURATION = gql`
+  query GetBoardConfiguration($boardConfigId: String!) {
+    boardConfiguration(boardConfigId: $boardConfigId) {
+      BoardConfigId
+      BoardName
+      BoardSlug
+      Description
+      UserId
+      IsDefault
+      IsActive
+      CreatedDate
+      ModifiedDate
+      CreatedBy
+      ModifiedBy
+    }
+  }
+`;
+
+export const GET_BOARD_CONFIGURATION_BY_SLUG = gql`
+  query GetBoardConfigurationBySlug($boardSlug: String!) {
+    boardConfigurationBySlug(boardSlug: $boardSlug) {
+      BoardConfigId
+      BoardName
+      BoardSlug
+      Description
+      UserId
+      IsDefault
+      IsActive
+      CreatedDate
+      ModifiedDate
+      CreatedBy
+      ModifiedBy
+    }
+  }
+`;
+
+export const GET_DEFAULT_BOARD_CONFIGURATION = gql`
+  query GetDefaultBoardConfiguration {
+    defaultBoardConfiguration {
+      BoardConfigId
+      BoardName
+      BoardSlug
+      Description
+      UserId
+      IsDefault
+      IsActive
+      CreatedDate
+      ModifiedDate
+      CreatedBy
+      ModifiedBy
+    }
+  }
+`;
+
+// Board Configuration Mutations
+export const CREATE_BOARD_CONFIGURATION = gql`
+  mutation CreateBoardConfiguration($boardConfig: BoardConfigurationInput!) {
+    createBoardConfiguration(boardConfig: $boardConfig) {
+      boardConfiguration {
+        BoardConfigId
+        BoardName
+        BoardSlug
+        Description
+        UserId
+        IsDefault
+        IsActive
+        CreatedDate
+        ModifiedDate
+        CreatedBy
+        ModifiedBy
+      }
+    }
+  }
+`;
+
+export const UPDATE_BOARD_CONFIGURATION = gql`
+  mutation UpdateBoardConfiguration($boardConfigId: String!, $boardConfig: BoardConfigurationUpdateInput!) {
+    updateBoardConfiguration(boardConfigId: $boardConfigId, boardConfig: $boardConfig) {
+      boardConfiguration {
+        BoardConfigId
+        BoardName
+        BoardSlug
+        Description
+        UserId
+        IsDefault
+        IsActive
+        CreatedDate
+        ModifiedDate
+        CreatedBy
+        ModifiedBy
+      }
+    }
+  }
+`;
+
+export const DELETE_BOARD_CONFIGURATION = gql`
+  mutation DeleteBoardConfiguration($boardConfigId: String!) {
+    deleteBoardConfiguration(boardConfigId: $boardConfigId) {
+      success
+    }
+  }
+`;

--- a/frontend/src/hooks/useGraphQLApi.ts
+++ b/frontend/src/hooks/useGraphQLApi.ts
@@ -24,6 +24,13 @@ import {
   CREATE_TOWNSHIP,
   UPDATE_TOWNSHIP,
   DELETE_TOWNSHIP,
+  GET_BOARD_CONFIGURATIONS,
+  GET_BOARD_CONFIGURATION,
+  GET_BOARD_CONFIGURATION_BY_SLUG,
+  GET_DEFAULT_BOARD_CONFIGURATION,
+  CREATE_BOARD_CONFIGURATION,
+  UPDATE_BOARD_CONFIGURATION,
+  DELETE_BOARD_CONFIGURATION,
 } from '../graphql/queries';
 
 import {
@@ -40,7 +47,10 @@ import {
   SurveyStatus,
   Township,
   TownshipCreate,
-  TownshipListResponse
+  TownshipListResponse,
+  BoardConfiguration,
+  BoardConfigurationCreate,
+  BoardConfigurationUpdate
 } from '../types';
 
 // Customer hooks
@@ -396,6 +406,105 @@ export const useDeleteTownship = () => {
       refetchQueries: [GET_TOWNSHIPS],
     });
     return (result.data as any).deleteTownship.success;
+  };
+
+  return { remove, loading, error };
+};
+
+// Board Configuration hooks
+export const useBoardConfigurations = () => {
+  const { data, loading, error, refetch } = useQuery(GET_BOARD_CONFIGURATIONS);
+
+  return {
+    data: (data as any)?.boardConfigurations as BoardConfiguration[] | undefined,
+    loading,
+    error,
+    refetch,
+  };
+};
+
+export const useBoardConfiguration = (boardConfigId: string) => {
+  const { data, loading, error } = useQuery(GET_BOARD_CONFIGURATION, {
+    variables: { boardConfigId },
+    skip: !boardConfigId,
+  });
+
+  return {
+    data: (data as any)?.boardConfiguration as BoardConfiguration | undefined,
+    loading,
+    error,
+  };
+};
+
+export const useBoardConfigurationBySlug = (boardSlug: string) => {
+  const { data, loading, error, refetch } = useQuery(GET_BOARD_CONFIGURATION_BY_SLUG, {
+    variables: { boardSlug },
+    skip: !boardSlug,
+  });
+
+  return {
+    data: (data as any)?.boardConfigurationBySlug as BoardConfiguration | undefined,
+    loading,
+    error,
+    refetch,
+  };
+};
+
+export const useDefaultBoardConfiguration = () => {
+  const { data, loading, error, refetch } = useQuery(GET_DEFAULT_BOARD_CONFIGURATION);
+
+  return {
+    data: (data as any)?.defaultBoardConfiguration as BoardConfiguration | undefined,
+    loading,
+    error,
+    refetch,
+  };
+};
+
+export const useCreateBoardConfiguration = () => {
+  const [createBoardConfiguration, { loading, error }] = useMutation(CREATE_BOARD_CONFIGURATION);
+
+  const create = async (boardConfig: BoardConfigurationCreate): Promise<BoardConfiguration> => {
+    const result = await createBoardConfiguration({
+      variables: {
+        boardConfig,
+      },
+      refetchQueries: [GET_BOARD_CONFIGURATIONS, GET_DEFAULT_BOARD_CONFIGURATION],
+    });
+    return (result.data as any).createBoardConfiguration.boardConfiguration;
+  };
+
+  return { create, loading, error };
+};
+
+export const useUpdateBoardConfiguration = () => {
+  const [updateBoardConfiguration, { loading, error }] = useMutation(UPDATE_BOARD_CONFIGURATION);
+
+  const update = async (id: string, boardConfig: BoardConfigurationUpdate): Promise<BoardConfiguration> => {
+    const result = await updateBoardConfiguration({
+      variables: {
+        boardConfigId: id,
+        boardConfig,
+      },
+      refetchQueries: [GET_BOARD_CONFIGURATIONS, GET_BOARD_CONFIGURATION, GET_DEFAULT_BOARD_CONFIGURATION],
+    });
+    return (result.data as any).updateBoardConfiguration.boardConfiguration;
+  };
+
+  return { update, loading, error };
+};
+
+export const useDeleteBoardConfiguration = () => {
+  const [deleteBoardConfiguration, { loading, error }] = useMutation(DELETE_BOARD_CONFIGURATION);
+
+  const remove = async (id: string): Promise<boolean> => {
+    const result = await deleteBoardConfiguration({
+      variables: {
+        boardConfigId: id,
+      },
+      refetchQueries: [GET_BOARD_CONFIGURATIONS, GET_DEFAULT_BOARD_CONFIGURATION],
+    });
+    return (result.data as any).deleteBoardConfiguration.success;
   };
 
   return { remove, loading, error };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -221,3 +221,37 @@ export interface PropertyListResponse extends PaginatedResponse<Property> {
 export interface TownshipListResponse extends PaginatedResponse<Township> {
   townships: Township[];
 }
+
+export interface BoardConfiguration {
+  BoardConfigId: string;
+  BoardName: string;
+  BoardSlug: string;
+  Description?: string;
+  UserId?: string;
+  IsDefault: boolean;
+  IsActive: boolean;
+  CreatedDate: string;
+  ModifiedDate: string;
+  CreatedBy?: string;
+  ModifiedBy?: string;
+}
+
+export interface BoardConfigurationCreate {
+  BoardName: string;
+  Description?: string;
+  UserId?: string;
+  IsDefault?: boolean;
+  IsActive?: boolean;
+}
+
+export interface BoardConfigurationUpdate {
+  BoardName?: string;
+  BoardSlug?: string;
+  Description?: string;
+  IsDefault?: boolean;
+  IsActive?: boolean;
+}
+
+export interface BoardConfigurationListResponse extends PaginatedResponse<BoardConfiguration> {
+  board_configurations: BoardConfiguration[];
+}


### PR DESCRIPTION
Implement full-stack board renaming feature with:
- Backend: BoardConfiguration model, CRUD operations, REST/GraphQL APIs
- Frontend: Inline editing UI, slug-based routing, real-time navigation updates
- Database: Seeding and persistent storage in DynamoDB
- Code quality: Fix ESLint warnings and remove unused imports

Users can now rename boards via UI with automatic URL updates.